### PR TITLE
Add option to serialise with only spaces, no tabs

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,11 +14,13 @@ const minimatch = require('minimatch');
  */
 class GitAttributes {
 
-    constructor() {
+    constructor(opts) {
         /** @type {GitAttributes.Rule[]} */
         this._rules = [];
 
         this.rules = [];
+
+        this.useOnlySpaces = opts && opts.useOnlySpaces;
     }
 
     /**
@@ -115,7 +117,7 @@ class GitAttributes {
         let lines = [];
 
         for (let rule of this.rules) {
-            let line = GitAttributes.serializeRule(rule);
+            let line = this.serializeRule(rule);
             if (line !== null)
                 lines.push(line);
         }
@@ -245,7 +247,7 @@ class GitAttributes {
      * @param {GitAttributes.Rule|null} rule
      * @returns {String|null}
      */
-    static serializeRule(rule) {
+    serializeRule(rule) {
         if (!rule)
             return null;
 
@@ -291,7 +293,8 @@ class GitAttributes {
             }
         }
 
-        return out + (attrsOuts ? '\t' + attrsOuts : '');
+        let delimiter = this.useOnlySpaces ? ' ' : '\t';
+        return out + (attrsOuts ? delimiter + attrsOuts : '');
     }
 
     /**

--- a/tests/parse_test.js
+++ b/tests/parse_test.js
@@ -214,4 +214,13 @@ describe('Read then write', async () => {
         assert.equal(attrs.serialize(), output);
     });
 
+    it(`Write only with spaces`, async () => {
+        let input = 'sample.txt\ttext=auto\n\n#this is a comment\n**/sample.txt\tflag=false';
+        let output = 'sample.txt text=auto\n\n#this is a comment\n**/sample.txt flag=false\n';
+
+        let attrs = new GitAttributes({ useOnlySpaces: true });
+        attrs.parse(input, true, true);
+
+        assert.equal(attrs.serialize(), output);
+    });
 });


### PR DESCRIPTION
It was raised in an issue in my application Git Locks Manager (which uses your library, thanks so much for making it!) that when there are tabs in the git attributes file the read-only setting isn't set on windows. I tested it and I was able to reproduce it. Here is a link to the [original issue](https://github.com/Noxdew/git-locks-manager/issues/146).

I tried looking up in the docs and online but since this is part of Git that is used a lot less than the core offering there aren't many discussions about that. Because of this I didn't want to just swap your prettier formatting. Instead I've added an option (which I can set within Git Locks Manager) to serialise rules with only spaces.

I tried to minimise the breaking changes. The constructor change shouldn't be breaking, however, I had to change serializeRule from static to instance, so if people are using it directly this will be a breaking change.

Thanks for your time to review and share your thoughts :) 

